### PR TITLE
Rename and document Mifare tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This repository contains tools and documentation for working with NFC cards, inc
 ## Project Structure
 
 - `nfc.py` — Main Python script for NFC card operations.
-- `mirafare_tool.py` — Additional utilities for working with Mifare cards.
+- `mifare_tool.py` — Additional utilities for working with Mifare cards.
 - `development-breakdown.md` — Breakdown of development tasks and features.
 - `development-milestones.md` — Milestones and progress tracking.
-- `mirafare-tool-ui-breakdown.md` — UI planning and breakdown for the tool.
+- `mifare-tool-ui-breakdown.md` — UI planning and breakdown for the tool.
 - `tech-stack-recommendation.md` — Recommendations and rationale for the chosen tech stack.
 - `.gitignore` — Ensures only relevant files are tracked by git.
 
@@ -31,7 +31,7 @@ This repository contains tools and documentation for working with NFC cards, inc
      ```
 
 3. **Explore the scripts:**
-   - Run `nfc.py` or `mirafare_tool.py` as needed for your NFC card tasks.
+   - Run `nfc.py` or `mifare_tool.py` as needed for your NFC card tasks.
 
 ## Contribution
 

--- a/mifare-tool-ui-breakdown.md
+++ b/mifare-tool-ui-breakdown.md
@@ -1,5 +1,5 @@
 
-# 1. mirafare-tool-ui-breakdown
+# 1. mifare-tool-ui-breakdown
 
 ## Key UI Components
 

--- a/mifare_utils.py
+++ b/mifare_utils.py
@@ -1,0 +1,61 @@
+"""Utility functions for parsing keys and access bits for Mifare cards."""
+
+import re
+
+
+def parse_key(key_str):
+    """Convert a hex key string into a list of integers.
+
+    The key string must contain six two-digit hex values separated by spaces.
+
+    Args:
+        key_str: Key string such as "FF FF FF FF FF FF".
+
+    Returns:
+        List of six integers representing the key bytes.
+
+    Raises:
+        ValueError: If ``key_str`` is not in the expected format.
+    """
+    parts = key_str.strip().split()
+    if len(parts) != 6 or any(not re.fullmatch(r"[0-9a-fA-F]{2}", p) for p in parts):
+        raise ValueError("Key must be six two-digit hex values")
+    return [int(p, 16) for p in parts]
+
+
+def parse_access_bits(access_bytes):
+    """Return access bit tuples for blocks 0-3."""
+    c1, c2, c3 = [], [], []
+    for i in range(4):
+        c1.append((access_bytes[1] >> (4 + i)) & 1)
+        c2.append((access_bytes[2] >> i) & 1)
+        c3.append((access_bytes[2] >> (4 + i)) & 1)
+    return list(zip(c1, c2, c3))
+
+
+def mifare_rights(cbits, block):
+    """Translate access bits into human-readable rights."""
+    if block < 3:
+        table = {
+            (0, 0, 0): "Read: A/B, Write: A/B, Inc: A/B, Dec: A/B",
+            (0, 1, 0): "Read: A/B, Write: -, Inc: -, Dec: -",
+            (1, 0, 0): "Read: A/B, Write: B, Inc: B, Dec: A/B",
+            (1, 1, 0): "Read: A/B, Write: B, Inc: -, Dec: -",
+            (0, 0, 1): "Read: A/B, Write: -, Inc: -, Dec: -",
+            (0, 1, 1): "Read: B, Write: B, Inc: B, Dec: B",
+            (1, 0, 1): "Read: -, Write: -, Inc: -, Dec: -",
+            (1, 1, 1): "Read: B, Write: -, Inc: -, Dec: -",
+        }
+        return table.get(cbits, "?")
+
+    table = {
+        (0, 0, 0): "Key A: Read/Write, Access Bits: Write, Key B: Read/Write",
+        (0, 1, 0): "Key A: -, Access Bits: Write, Key B: Read/Write",
+        (1, 0, 0): "Key A: Read, Access Bits: -, Key B: Read",
+        (1, 1, 0): "Key A: -, Access Bits: -, Key B: Read",
+        (0, 0, 1): "Key A: Read/Write, Access Bits: Write, Key B: -",
+        (0, 1, 1): "Key A: -, Access Bits: Write, Key B: -",
+        (1, 0, 1): "Key A: Read, Access Bits: -, Key B: -",
+        (1, 1, 1): "Key A: -, Access Bits: -, Key B: -",
+    }
+    return table.get(cbits, "?")


### PR DESCRIPTION
## Summary
- rename `mirafare_tool.py` to `mifare_tool.py`
- rename `mirafare-tool-ui-breakdown.md`
- add `mifare_utils.py` module with helper functions
- fix placeholder table naming and cleanup
- ensure connections are always closed and add input validation
- add docstrings and update README

## Testing
- `python3 -m py_compile mifare_tool.py mifare_utils.py nfc.py`

------
https://chatgpt.com/codex/tasks/task_e_6851e7daa1b083229507ba136a6c872e